### PR TITLE
Improve handling of missing sensor data during initialization

### DIFF
--- a/esphome/components/sauna360/sauna360.cpp
+++ b/esphome/components/sauna360/sauna360.cpp
@@ -22,6 +22,9 @@ void SAUNA360Component::setup() {
   if (this->heater_relay_switch_ != nullptr) {
     this->heater_relay_switch_->publish_state(false);
   }
+  if (this->bath_temperature_number_ != nullptr) {
+    this->bath_temperature_number_->publish_state(0.0);
+  }
   if (this->light_relay_switch_ == nullptr) {
   }
   if (this->heater_relay_switch_ == nullptr) {


### PR DESCRIPTION
Ensure the climate component operates correctly by initializing the temperature to 0°C when no valid temperature value is received. This prevents issues caused by uninitialized or missing data.